### PR TITLE
fix npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "cd server && node server.js",
-    "install": "cd server && npm install && cd client && npm install",
+    "install": "cd server && npm install && cd ../client && npm install",
     "dev": "concurrently \"cd server && npm run dev\" \"cd client && npm run dev\""
   },
   "author": "",


### PR DESCRIPTION
added the missing `../` when changing (`cd`) into `client` folder. 

@danibarker 